### PR TITLE
feat: allow use of access token

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -13,22 +13,23 @@ const action = (core.getInput('action', { required: true }) || '').toLowerCase()
 const clientId = core.getInput('client_id', { required: true })
 const secret = core.getInput('client_secret', { required: true })
 const token = core.getInput('refresh_token', { required: true })
+const access_token = core.getInput('access_token', { required: false })
 const zip = core.getInput('zip_file', { required: true })
 const extId = core.getInput('extension_id', { required: true })
 
 switch (action) {
   case 'upload':
-    upload(clientId, secret, token, zip, extId)
+    upload(clientId, secret, token, access_token, zip, extId)
       .then(_ => core.info('Upload to webstore completed'))
       .catch(error => core.setFailed(error.message))
     break
   case 'publish':
-    publish(clientId, secret, token, zip, extId, false)
+    publish(clientId, secret, token, access_token, zip, extId, false)
       .then(_ => core.info('Publish to webstore completed'))
       .catch(error => core.setFailed(error.message))
     break
   case 'testers':
-    publish(clientId, secret, token, zip, extId, true)
+    publish(clientId, secret, token, access_token, zip, extId, true)
       .then(_ => core.info('Publish webstore testers completed'))
       .catch(error => core.setFailed(error.message))
     break

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -15,6 +15,8 @@ program
   .arguments('<client_id>')
   .arguments('<client_secret>')
   .arguments('<refresh_token>')
+  .arguments('<access_token>')
+  .arguments('<refresh_token>')
   .arguments('<zip_file>')
   .arguments('<extension_id>')
   .option('-t, --testers', 'publish to testers')
@@ -22,7 +24,8 @@ program
     clientId: string,
     secret: string,
     token: string,
+    accessToken: string,
     zipPath: string,
     extId: string
-  ) => publish(clientId, secret, token, zipPath, extId, (program as OptionValues).testers))
+  ) => publish(clientId, secret, token, accessToken, zipPath, extId, (program as OptionValues).testers))
   .parse(process.argv)

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -15,13 +15,15 @@ program
   .arguments('<client_id>')
   .arguments('<client_secret>')
   .arguments('<refresh_token>')
+  .arguments('<access_token>')
   .arguments('<zip_file>')
   .arguments('<extension_id>')
   .action((
     clientId: string,
     secret: string,
     token: string,
+    accessToken: string,
     zipPath: string,
     extId: string
-  ) => (upload(clientId, secret, token, zipPath, extId) as Promise<any>))
+  ) => (upload(clientId, secret, token, accessToken, zipPath, extId) as Promise<any>))
   .parse(process.argv)


### PR DESCRIPTION
With the introduction of OIDC tokens into GitHub Actions workflows, it is now possible to use a short-lived access token to publish to the Chrome Web Store. This PR adds support for leveraging an access token directly as opposed to using oauth credentials.